### PR TITLE
Fix: Implement missing GetApiTalkRouletteThemes method

### DIFF
--- a/backend/internal/server.go
+++ b/backend/internal/server.go
@@ -51,3 +51,9 @@ func (s *Server) PostApiPlanningPokerSessionsSessionIdRounds(ctx echo.Context, s
 func (s *Server) GetApiPlanningPokerWsSessionId(ctx echo.Context, sessionID string) error {
 	return s.planningpokerServer.HandleGetWsSessionId(ctx, sessionID)
 }
+
+// GetApiTalkRouletteThemes implements api.ServerInterface.
+func (s *Server) GetApiTalkRouletteThemes(ctx echo.Context, params api.GetApiTalkRouletteThemesParams) error {
+	// TODO: Implement
+	return nil
+}


### PR DESCRIPTION
I added a placeholder implementation for the `GetApiTalkRouletteThemes` method to `backend/internal/server.go`. This method was required by the `api.ServerInterface` and its absence was causing a build failure.

With this change, the build is successful and all existing tests in the backend pass.