### PR TITLE
refactor(e2e): JoinSessionPage.spec.ts を POM を使用するようにリファクタリング

### DIFF
--- a/e2e/pom/planning-poker/JoinSessionPage.ts
+++ b/e2e/pom/planning-poker/JoinSessionPage.ts
@@ -35,20 +35,4 @@ export class JoinSessionPagePom {
   public async clickJoinSessionButton(): Promise<void> {
     await this.joinSessionButton.click();
   }
-
-  public async inputUserName(userName: string): Promise<void> {
-    await this.page.getByLabel("あなたの名前").fill(userName);
-  }
-
-  public async clickJoinButton(): Promise<void> {
-    await this.page
-      .getByRole("button", { name: "セッションに参加", exact: true })
-      .click();
-    await this.page.waitForEvent("websocket");
-  }
-
-  public async joinSession(userName: string): Promise<void> {
-    await this.inputUserName(userName);
-    await this.clickJoinButton();
-  }
 }

--- a/e2e/pom/planning-poker/JoinSessionPage.ts
+++ b/e2e/pom/planning-poker/JoinSessionPage.ts
@@ -1,10 +1,39 @@
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
 export class JoinSessionPagePom {
   private page: Page;
 
+  readonly sessionIdInput: Locator;
+  readonly yourNameInput: Locator;
+  readonly joinSessionButton: Locator;
+  readonly backLink: Locator;
+  readonly alertMessage: Locator;
+
   constructor(page: Page) {
     this.page = page;
+    this.sessionIdInput = page.getByLabel("セッションID");
+    this.yourNameInput = page.getByLabel("あなたの名前");
+    this.joinSessionButton = page.getByRole("button", {
+      name: "セッションに参加",
+    });
+    this.backLink = page.getByRole("link", { name: "戻る" });
+    this.alertMessage = page.locator(".alert");
+  }
+
+  public async goto(): Promise<void> {
+    await this.page.goto("/planning-poker/sessions/join");
+  }
+
+  public async fillSessionId(sessionId: string): Promise<void> {
+    await this.sessionIdInput.fill(sessionId);
+  }
+
+  public async fillYourName(yourName: string): Promise<void> {
+    await this.yourNameInput.fill(yourName);
+  }
+
+  public async clickJoinSessionButton(): Promise<void> {
+    await this.joinSessionButton.click();
   }
 
   public async inputUserName(userName: string): Promise<void> {

--- a/e2e/pom/planning-poker/SessionPage.ts
+++ b/e2e/pom/planning-poker/SessionPage.ts
@@ -71,7 +71,9 @@ export class SessionPagePom {
     const participantPage = await this.page.context().newPage();
     await participantPage.goto(inviteLink as string);
     const participantPom = new JoinSessionPagePom(participantPage);
-    await participantPom.joinSession(participantName);
+    await participantPom.fillYourName(participantName);
+    await participantPom.clickJoinSessionButton();
+    await participantPage.waitForEvent("websocket");
 
     return participantPage;
   }

--- a/e2e/pom/talk-roulette/TalkRouletteTopPagePom.ts
+++ b/e2e/pom/talk-roulette/TalkRouletteTopPagePom.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
 export class TalkRouletteTopPagePom {
   readonly page: Page;
@@ -12,7 +12,9 @@ export class TalkRouletteTopPagePom {
   constructor(page: Page) {
     this.page = page;
     this.talkTheme = page.getByTestId("talk-theme");
-    this.newThemeButton = page.getByRole("button", { name: "別のテーマを引く" });
+    this.newThemeButton = page.getByRole("button", {
+      name: "別のテーマを引く",
+    });
     this.goodThemeButton = page.getByRole("button", { name: "良いテーマ" });
     this.badThemeButton = page.getByRole("button", { name: "悪いテーマ" });
     this.feedbackMessage = page.getByTestId("feedback-message");

--- a/e2e/tests/planning-poker/CreateSessionPage.spec.ts
+++ b/e2e/tests/planning-poker/CreateSessionPage.spec.ts
@@ -36,10 +36,7 @@ test.describe("セッション作成画面", () => {
   test("戻るボタンがあること", async () => {
     const backLink = createSessionPage.backLink;
     await expect(backLink).toBeVisible();
-    await expect(backLink).toHaveAttribute(
-      "href",
-      "/planning-poker",
-    );
+    await expect(backLink).toHaveAttribute("href", "/planning-poker");
   });
 
   test("名前が入力されていないときはセッション作成ボタンが押せないこと", async () => {

--- a/e2e/tests/planning-poker/JoinSessionPage.spec.ts
+++ b/e2e/tests/planning-poker/JoinSessionPage.spec.ts
@@ -1,9 +1,13 @@
 import crypto from "node:crypto";
 import { expect, test } from "@playwright/test";
+import { JoinSessionPagePom } from "../../pom/planning-poker/JoinSessionPage";
 
 test.describe("セッション参加画面", () => {
+  let joinSessionPage: JoinSessionPagePom;
+
   test.beforeEach(async ({ page }) => {
-    await page.goto("/planning-poker/sessions/join");
+    joinSessionPage = new JoinSessionPagePom(page);
+    await joinSessionPage.goto();
   });
 
   test("タイトルがあること", async ({ page }) => {
@@ -11,55 +15,41 @@ test.describe("セッション参加画面", () => {
     await expect(page).toHaveTitle(/Web Toolbox/);
   });
 
-  test("セッションIDを入力できること", async ({ page }) => {
-    await expect(page.getByLabel("セッションID")).toBeVisible();
+  test("セッションIDを入力できること", async () => {
+    await expect(joinSessionPage.sessionIdInput).toBeVisible();
   });
 
-  test("参加者名を入力できること", async ({ page }) => {
-    await expect(page.getByLabel("あなたの名前")).toBeVisible();
+  test("参加者名を入力できること", async () => {
+    await expect(joinSessionPage.yourNameInput).toBeVisible();
   });
 
-  test("「セッションに参加」ボタンがあること", async ({ page }) => {
-    await expect(
-      page.getByRole("button", { name: "セッションに参加" }),
-    ).toBeVisible();
+  test("「セッションに参加」ボタンがあること", async () => {
+    await expect(joinSessionPage.joinSessionButton).toBeVisible();
   });
 
-  test("戻るボタンがあること", async ({ page }) => {
-    await expect(page.getByRole("link", { name: "戻る" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "戻る" })).toHaveAttribute(
+  test("戻るボタンがあること", async () => {
+    await expect(joinSessionPage.backLink).toBeVisible();
+    await expect(joinSessionPage.backLink).toHaveAttribute(
       "href",
       "/planning-poker",
     );
   });
 
-  test("セッションIDと名前が入力されていないときはセッション参加ボタンが押せないこと", async ({
-    page,
-  }) => {
-    const joinSessionButton = page.getByRole("button", {
-      name: "セッションに参加",
-    });
-    await expect(joinSessionButton).toBeDisabled();
+  test("セッションIDと名前が入力されていないときはセッション参加ボタンが押せないこと", async () => {
+    await expect(joinSessionPage.joinSessionButton).toBeDisabled();
   });
 
-  test("セッションIDと名前が入力されたときはセッション参加ボタンが押せること", async ({
-    page,
-  }) => {
-    await page.getByLabel("セッションID").fill("test-session-id");
-    await page.getByLabel("名前").fill("テストユーザー");
-    const joinSessionButton = page.getByRole("button", {
-      name: "セッションに参加",
-    });
-    await expect(joinSessionButton).toBeEnabled();
+  test("セッションIDと名前が入力されたときはセッション参加ボタンが押せること", async () => {
+    await joinSessionPage.fillSessionId("test-session-id");
+    await joinSessionPage.fillYourName("テストユーザー");
+    await expect(joinSessionPage.joinSessionButton).toBeEnabled();
   });
 
-  test("存在しないセッションIDを入力してセッション参加ボタンを押すと画面遷移せずにエラーが表示されること", async ({
-    page,
-  }) => {
+  test("存在しないセッションIDを入力してセッション参加ボタンを押すと画面遷移せずにエラーが表示されること", async () => {
     const invalidSessionId = crypto.randomUUID();
-    await page.getByLabel("セッションID").fill(invalidSessionId);
-    await page.getByLabel("名前").fill("テストユーザー");
-    await page.getByRole("button", { name: "セッションに参加" }).click();
-    await expect(page.locator(".alert")).toBeVisible();
+    await joinSessionPage.fillSessionId(invalidSessionId);
+    await joinSessionPage.fillYourName("テストユーザー");
+    await joinSessionPage.clickJoinSessionButton();
+    await expect(joinSessionPage.alertMessage).toBeVisible();
   });
 });

--- a/e2e/tests/talk-roulette/TalkRouletteTopPage.spec.ts
+++ b/e2e/tests/talk-roulette/TalkRouletteTopPage.spec.ts
@@ -17,13 +17,17 @@ test("トークルーレットページにアクセスできること", async ({
 test("初期表示でテーマが表示されていること", async () => {
   await expect(talkRoulettePage.talkTheme).toBeVisible();
   await expect(talkRoulettePage.talkTheme).not.toBeEmpty();
-  await expect(talkRoulettePage.talkTheme).not.toHaveText("テーマを読み込み中...");
+  await expect(talkRoulettePage.talkTheme).not.toHaveText(
+    "テーマを読み込み中...",
+  );
 });
 
 test("「新しいテーマ」ボタンをクリックするとテーマが変更されること", async () => {
   const initialTheme = await talkRoulettePage.getTalkThemeText();
   await talkRoulettePage.clickNewThemeButton();
-  await expect(talkRoulettePage.talkTheme).not.toHaveText(initialTheme as string);
+  await expect(talkRoulettePage.talkTheme).not.toHaveText(
+    initialTheme as string,
+  );
 });
 
 test("「良いね」ボタンをクリックするとフィードバックメッセージが表示されること", async () => {
@@ -45,5 +49,7 @@ test("「良くないね」ボタンをクリックするとフィードバッ�
 test("ジャンルを選択するとテーマが変更されること", async () => {
   const initialTheme = await talkRoulettePage.getTalkThemeText();
   await talkRoulettePage.selectGenre("hobby");
-  await expect(talkRoulettePage.talkTheme).not.toHaveText(initialTheme as string);
+  await expect(talkRoulettePage.talkTheme).not.toHaveText(
+    initialTheme as string,
+  );
 });


### PR DESCRIPTION
`e2e/tests/planning-poker/JoinSessionPage.spec.ts` を Playwright の Page Object Model (POM) パターンに準拠するようにリファクタリングしました。

- `JoinSessionPagePom` のインポートを追加。
- `test.beforeEach` ブロックで `JoinSessionPagePom` インスタンスを初期化。
- Playwright セレクタを適切な `JoinSessionPagePom` のプロパティとメソッドに置き換え。
- `JoinSessionPagePom` に `goto`、`fillSessionId`、`fillYourName`、`clickJoinSessionButton` メソッドと `sessionIdInput`、`yourNameInput`、`joinSessionButton`、`backLink`、`alertMessage` ロケーターを追加。

fixed #108