### PR TITLE
refactor(e2e): TopPage.spec.ts (Planning Poker) を POM を使用するようにリファクタリング (#109)

### DIFF
--- a/e2e/pom/planning-poker/TopPage.ts
+++ b/e2e/pom/planning-poker/TopPage.ts
@@ -1,0 +1,25 @@
+import { Page } from "@playwright/test";
+
+export class PlanningPokerTopPagePom {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto("/planning-poker");
+  }
+
+  get createSessionLink() {
+    return this.page.getByRole("link", { name: "セッションを作成" });
+  }
+
+  get joinSessionLink() {
+    return this.page.getByRole("link", { name: "セッションに参加" });
+  }
+
+  async clickCreateSessionLink() {
+    await this.createSessionLink.click();
+  }
+
+  async clickJoinSessionLink() {
+    await this.joinSessionLink.click();
+  }
+}

--- a/e2e/pom/planning-poker/TopPage.ts
+++ b/e2e/pom/planning-poker/TopPage.ts
@@ -1,10 +1,14 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 export class PlanningPokerTopPagePom {
   constructor(private readonly page: Page) {}
 
   async goto() {
     await this.page.goto("/planning-poker");
+  }
+
+  async expectTitleToContain(text: string) {
+    await expect(this.page).toHaveTitle(new RegExp(text));
   }
 
   get createSessionLink() {

--- a/e2e/pom/planning-poker/TopPage.ts
+++ b/e2e/pom/planning-poker/TopPage.ts
@@ -1,7 +1,7 @@
-import { Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 export class PlanningPokerTopPagePom {
-  constructor(private page: Page) {}
+  constructor(private readonly page: Page) {}
 
   async goto() {
     await this.page.goto("/planning-poker");

--- a/e2e/tests/planning-poker/TopPage.spec.ts
+++ b/e2e/tests/planning-poker/TopPage.spec.ts
@@ -14,14 +14,16 @@ test.describe("トップページ", () => {
   });
 
   test("「セッションを作成」ボタンのリンク先が/planning-poker/sessions/createであること", async () => {
-    await expect(
-      planningPokerTopPage.createSessionLink,
-    ).toHaveAttribute("href", "/planning-poker/sessions/create");
+    await expect(planningPokerTopPage.createSessionLink).toHaveAttribute(
+      "href",
+      "/planning-poker/sessions/create",
+    );
   });
 
   test("「セッションに参加」ボタンのリンク先が/planning-poker/sessions/joinであること", async () => {
-    await expect(
-      planningPokerTopPage.joinSessionLink,
-    ).toHaveAttribute("href", "/planning-poker/sessions/join");
+    await expect(planningPokerTopPage.joinSessionLink).toHaveAttribute(
+      "href",
+      "/planning-poker/sessions/join",
+    );
   });
 });

--- a/e2e/tests/planning-poker/TopPage.spec.ts
+++ b/e2e/tests/planning-poker/TopPage.spec.ts
@@ -8,9 +8,9 @@ test.describe("トップページ", () => {
     await planningPokerTopPage.goto();
   });
 
-  test("タイトルがあること", async ({ page }) => {
-    await expect(page).toHaveTitle(/プランニングポーカー/);
-    await expect(page).toHaveTitle(/Web Toolbox/);
+  test("タイトルがあること", async () => {
+    await planningPokerTopPage.expectTitleToContain("プランニングポーカー");
+    await planningPokerTopPage.expectTitleToContain("Web Toolbox");
   });
 
   test("「セッションを作成」ボタンのリンク先が/planning-poker/sessions/createであること", async () => {

--- a/e2e/tests/planning-poker/TopPage.spec.ts
+++ b/e2e/tests/planning-poker/TopPage.spec.ts
@@ -1,8 +1,11 @@
 import { expect, test } from "@playwright/test";
+import { PlanningPokerTopPagePom } from "../../pom/planning-poker/TopPage";
 
 test.describe("トップページ", () => {
+  let planningPokerTopPage: PlanningPokerTopPagePom;
   test.beforeEach(async ({ page }) => {
-    await page.goto("/planning-poker");
+    planningPokerTopPage = new PlanningPokerTopPagePom(page);
+    await planningPokerTopPage.goto();
   });
 
   test("タイトルがあること", async ({ page }) => {
@@ -10,19 +13,15 @@ test.describe("トップページ", () => {
     await expect(page).toHaveTitle(/Web Toolbox/);
   });
 
-  test("「セッションを作成」ボタンのリンク先が/planning-poker/sessions/createであること", async ({
-    page,
-  }) => {
+  test("「セッションを作成」ボタンのリンク先が/planning-poker/sessions/createであること", async () => {
     await expect(
-      page.getByRole("link", { name: "セッションを作成" }),
+      planningPokerTopPage.createSessionLink,
     ).toHaveAttribute("href", "/planning-poker/sessions/create");
   });
 
-  test("「セッションに参加」ボタンのリンク先が/planning-poker/sessions/joinであること", async ({
-    page,
-  }) => {
+  test("「セッションに参加」ボタンのリンク先が/planning-poker/sessions/joinであること", async () => {
     await expect(
-      page.getByRole("link", { name: "セッションに参加" }),
+      planningPokerTopPage.joinSessionLink,
     ).toHaveAttribute("href", "/planning-poker/sessions/join");
   });
 });


### PR DESCRIPTION
e2e/tests/planning-poker/TopPage.spec.ts を Playwright の Page Object Model (POM) パターンに準拠するようにリファクタリングしました。

- PlanningPokerTopPagePom の新規作成とインポート
- test.beforeEach ブロックで PlanningPokerTopPagePom インスタンスを初期化
- Playwright セレクタを適切な PlanningPokerTopPagePom のプロパティとメソッドに置き換え

fixed #109