### PR TITLE
refactor(e2e): top-page.spec.ts (Root Top Page) を POM を使用するようにリファクタリング (#110)

### DIFF
--- a/e2e/pom/TopPage.ts
+++ b/e2e/pom/TopPage.ts
@@ -1,0 +1,29 @@
+import { expect, type Page } from "@playwright/test";
+
+export class TopPagePom {
+  constructor(private readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto("/");
+  }
+
+  async expectTitleToContain(text: string) {
+    await expect(this.page).toHaveTitle(new RegExp(text));
+  }
+
+  get planningPokerLink() {
+    return this.page.getByRole("link", { name: "プランニングポーカー" });
+  }
+
+  get talkRouletteLink() {
+    return this.page.getByRole("link", { name: "トークルーレット" });
+  }
+
+  async clickPlanningPokerLink() {
+    await this.planningPokerLink.click();
+  }
+
+  async clickTalkRouletteLink() {
+    await this.talkRouletteLink.click();
+  }
+}

--- a/e2e/tests/top-page.spec.ts
+++ b/e2e/tests/top-page.spec.ts
@@ -1,31 +1,33 @@
 import { expect, test } from "@playwright/test";
+import { TopPagePom } from "../pom/TopPage";
+
+let topPage: TopPagePom;
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/");
+  topPage = new TopPagePom(page);
+  await topPage.goto();
 });
 
-test("タイトルが設定されていること", async ({ page }) => {
-  await expect(page).toHaveTitle(/Web Toolbox/);
+test("タイトルが設定されていること", async () => {
+  await topPage.expectTitleToContain("Web Toolbox");
 });
 
-test("プランニングポーカーへのリンクが存在すること", async ({ page }) => {
-  await expect(
-    page.getByRole("link", { name: "プランニングポーカー" }),
-  ).toBeVisible();
+test("プランニングポーカーへのリンクが存在すること", async () => {
+  await expect(topPage.planningPokerLink).toBeVisible();
 });
 
-test("トークルーレットへのリンクが存在すること", async ({ page }) => {
-  await expect(
-    page.getByRole("link", { name: "トークルーレット" }),
-  ).toBeVisible();
+test("トークルーレットへのリンクが存在すること", async () => {
+  await expect(topPage.talkRouletteLink).toBeVisible();
 });
 
-test("プランニングポーカーへのリンクをクリックできること", async ({ page }) => {
-  await page.getByRole("link", { name: "プランニングポーカー" }).click();
-  await expect(page).toHaveURL(/planning-poker/);
+test("プランニングポーカーへのリンクをクリックできること", async () => {
+  await topPage.clickPlanningPokerLink();
+  await topPage.page.waitForURL(/planning-poker/);
+  await topPage.expectTitleToContain("プランニングポーカー");
 });
 
-test("トークルーレットへのリンクをクリックできること", async ({ page }) => {
-  await page.getByRole("link", { name: "トークルーレット" }).click();
-  await expect(page).toHaveURL(/talk-roulette/);
+test("トークルーレットへのリンクをクリックできること", async () => {
+  await topPage.clickTalkRouletteLink();
+  await topPage.page.waitForURL(/talk-roulette/);
+  await expect(topPage.page.getByRole("heading", { name: "今日のトークテーマ" })).toBeVisible();
 });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -65,7 +65,15 @@ if (rootElement) {
                 </>
               }
             />
-            <Route path="/talk-roulette" element={<TalkRouletteTopPage />} />
+            <Route
+              path="/talk-roulette"
+              element={
+                <>
+                  <title>トークルーレット | Web Toolbox</title>
+                  <TalkRouletteTopPage />
+                </>
+              }
+            />
           </Route>
         </Routes>
       </BrowserRouter>


### PR DESCRIPTION
e2e/tests/top-page.spec.ts を Playwright の Page Object Model (POM) パターンに準拠するようにリファクタリングしました。

- e2e/pom/TopPage.ts を新規作成し、ルートのトップページ要素をカプセル化
- test.beforeEach ブロックで TopPagePom インスタンスを初期化
- Playwright セレクタを適切な TopPagePom のプロパティとメソッドに置き換え
- frontend/src/main.tsx にトークルーレットページのタイトルを追加

fixed #110